### PR TITLE
Fixed read_user_by_id docstring

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/user.py
@@ -123,7 +123,7 @@ def read_user_by_id(
     db: Session = Depends(get_db),
 ):
     """
-    Get a specific user by username (email)
+    Get a specific user by id
     """
     user = crud.user.get(db, user_id=user_id)
     if user == current_user:


### PR DESCRIPTION
Incorrectly documented as "Get a specific user by username (email)". Changed to "Get a specific user by id".